### PR TITLE
remove return this

### DIFF
--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -421,7 +421,7 @@ class HasMany extends Association {
       targetInstance.get(association.target.primaryKeyAttribute)
     );
 
-    return association.target.unscoped().update(update, _.defaults({where}, options)).return(this);
+    return association.target.unscoped().update(update, _.defaults({where}, options));
   }
 
   /**


### PR DESCRIPTION
fix #7668
change `hasMany` association's `remove` method returns operation result instead of `this`

_Thanks for wanting to fix something on Sequelize - we already love you long time! Please delete this text and fill in the template below. If unsure about something, just do as best as you're able._

_If your PR only contains changes to documentation, you may skip the template below._

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
